### PR TITLE
TMC: Dungeon Items settings

### DIFF
--- a/worlds/tmc/Items.py
+++ b/worlds/tmc/Items.py
@@ -342,49 +342,27 @@ def get_item_pool(world: "MinishCapWorld") -> (list[MinishCapItem], list[MinishC
         multiworld.local_early_items[player][PROGRESSIVE_SWORD.item_name] = 1
 
     # TODO: add support for the other options, maybe clean this up so it's not a massive if/else branch
-    if world.options.dungeon_big_keys == DungeonItem.option_home_dungeon:
+    if world.options.dungeon_big_keys == DungeonItem.option_own_dungeon:
         pre_fill_pool.extend(pool_bigkeys())
     else:
         item_pool.extend(pool_bigkeys())
-    if world.options.dungeon_small_keys == DungeonItem.option_home_dungeon:
+    if world.options.dungeon_small_keys == DungeonItem.option_own_dungeon:
         pre_fill_pool.extend(pool_smallkeys())
     else:
         item_pool.extend(pool_smallkeys())
-    if world.options.dungeon_compasses == DungeonItem.option_home_dungeon:
+    if world.options.dungeon_compasses == DungeonItem.option_own_dungeon:
         pre_fill_pool.extend(pool_compass())
     else:
         item_pool.extend(pool_compass())
-    if world.options.dungeon_maps == DungeonItem.option_home_dungeon:
+    if world.options.dungeon_maps == DungeonItem.option_own_dungeon:
         pre_fill_pool.extend(pool_dungeonmaps())
     else:
         item_pool.extend(pool_dungeonmaps())
 
     if world.options.shuffle_elements.value is ShuffleElements.option_anywhere:
         item_pool.extend(pool_elements())
-    elif world.options.shuffle_elements.value is ShuffleElements.option_original_dungeon:
-        placements = {
-            TMCLocation.DEEPWOOD_PRIZE: EARTH_ELEMENT,
-            TMCLocation.COF_PRIZE: FIRE_ELEMENT,
-            TMCLocation.DROPLETS_PRIZE: WATER_ELEMENT,
-            TMCLocation.PALACE_PRIZE: WIND_ELEMENT,
-        }
-        for loc, element in placements.items():
-            multiworld.get_location(loc, player).place_locked_item(world.create_item(element.item_name))
-    elif world.options.shuffle_elements.value is ShuffleElements.option_own_dungeon:
-        dungeons = [
-            TMCLocation.DEEPWOOD_PRIZE,
-            TMCLocation.COF_PRIZE,
-            TMCLocation.DROPLETS_PRIZE,
-            TMCLocation.PALACE_PRIZE,
-            TMCLocation.FORTRESS_PRIZE,
-            TMCLocation.CRYPT_PRIZE
-        ]
-        elements = [EARTH_ELEMENT, FIRE_ELEMENT, WATER_ELEMENT, WIND_ELEMENT]
-        world.random.shuffle(dungeons)
-
-        for i, element in enumerate(elements):
-            multiworld.get_location(dungeons[i], player).place_locked_item(world.create_item(element.item_name))
-            world.options.start_hints.value.add(element.item_name)
+    else:
+        pre_fill_pool.extend(pool_elements())
 
     return (
         [world.create_item(item.item_name) for item in item_pool],

--- a/worlds/tmc/Options.py
+++ b/worlds/tmc/Options.py
@@ -3,16 +3,19 @@ from Options import Choice, DefaultOnToggle, Toggle, StartInventoryPool, PerGame
 
 class DungeonItem(Choice):
     value: int
-    # TODO: removed temporarily while `accessibility: minimal` is worked on
-    # option_removed = 0
-    # option_vanilla = 1
-    option_home_dungeon = 2
-    # option_home_region = 3
-    # option_any_dungeon = 4
-    # option_any_region = 5
-    option_anywhere = 6
-    alias_true = 6
-    alias_false = 2
+    # EternalCode's note: I want to experiment with a `closed` for small/big keys to actually remove them from the pool
+    # entirely and keep the doors closed. All locations behind them would be removed & inaccessible.
+    # Elements would need to be forced to be anywhere under this setting.
+    # option_closed = 0
+    # option_open = 1 # TMCR Removed
+    # option_vanilla = 2
+    option_own_dungeon = 0 # 3
+    # option_own_region = 4
+    # option_any_dungeon = 5
+    # option_any_region = 6
+    option_anywhere = 1 # 7
+    alias_true = 1
+    alias_false = 0
 
 class Rupeesanity(Toggle):
     """Add all rupees locations to the pool to be randomized."""
@@ -23,6 +26,9 @@ class ObscureSpots(Toggle):
     display_name = "Obscure Spots"
 
 class ShuffleElements(Choice):
+    # EternalCode's Note: I'd like to see ElementShuffle extend DungeonItem choice. ElementShuffle would
+    # get it's own unique `dungeon_prize` setting to keep current/default functionality. `own_dungeon` could then place
+    # a maximum of one element anywhere in the dungeon.
     """
     Lock elements to specific locations
     Original Dungeon: Elements are in the same dungeons as vanilla

--- a/worlds/tmc/Options.py
+++ b/worlds/tmc/Options.py
@@ -3,12 +3,13 @@ from Options import Choice, DefaultOnToggle, Toggle, StartInventoryPool, PerGame
 
 class DungeonItem(Choice):
     value: int
-    option_removed = 0
-    option_vanilla = 1
+    # TODO: removed temporarily while `accessibility: minimal` is worked on
+    # option_removed = 0
+    # option_vanilla = 1
     option_home_dungeon = 2
-    option_home_region = 3
-    option_any_dungeon = 4
-    option_any_region = 5
+    # option_home_region = 3
+    # option_any_dungeon = 4
+    # option_any_region = 5
     option_anywhere = 6
     alias_true = 6
     alias_false = 2
@@ -142,10 +143,10 @@ class MinishCapOptions(PerGameCommonOptions):
     rupeesanity: Rupeesanity
     obscure_spots: ObscureSpots
     early_weapon: EarlyWeapon
-    # dungeon_small_keys: SmallKeys
-    # dungeon_big_keys: BigKeys
-    # dungeon_maps: DungeonMaps
-    # dungeon_compasses: DungeonCompasses
+    dungeon_small_keys: SmallKeys
+    dungeon_big_keys: BigKeys
+    dungeon_maps: DungeonMaps
+    dungeon_compasses: DungeonCompasses
 
 def get_option_data(options: MinishCapOptions):
     """
@@ -186,7 +187,8 @@ def get_option_data(options: MinishCapOptions):
         "wind_crest_crenel": 0,
         "wind_crest_castor": 0,
         "wind_crest_clouds": 0,
-        "wind_crest_lake": 0,
+        "wind_crest_lake": 1,
+        "wind_crest_town": 1,
         "wind_crest_falls": 0,
         "wind_crest_south_field": 0,
         "wind_crest_minish_woods": 0,

--- a/worlds/tmc/Options.py
+++ b/worlds/tmc/Options.py
@@ -32,33 +32,49 @@ class ShuffleElements(Choice):
     """
     Lock elements to specific locations
     Original Dungeon: Elements are in the same dungeons as vanilla
-    Own Dungeon (false): Elements are shuffled between the 6 dungeon prizes
+    Own Dungeon (false/default): Elements are shuffled between the 6 dungeon prizes
     Anywhere (true): Elements are in completely random locations
     """
     display_name = "Element Shuffle"
     default = 1
-    option_original_dungeon = 0
+    option_original_dungeon = 0 # to be renamed to `vanilla`
     option_own_dungeon = 1
     option_anywhere = 2
     alias_true = 2
     alias_false = 1
 
 class SmallKeys(DungeonItem):
+    """
+    Own Dungeon (false/default): Randomized within the dungeon they're normally found in
+    Anywhere (true): Items are in completely random locations
+    """
     display_name = "Small Key Shuffle"
 
 class BigKeys(DungeonItem):
+    """
+    Own Dungeon (default/false): Randomized within the dungeon they're normally found in
+    Anywhere (true): Items are in completely random locations
+    """
     display_name = "Big Key Shuffle"
 
 class DungeonMaps(DungeonItem):
+    """
+    Own Dungeon (default/false): Randomized within the dungeon they're normally found in
+    Anywhere (true): Items are in completely random locations
+    """
     display_name = "Dungeon Maps Shuffle"
 
 class DungeonCompasses(DungeonItem):
+    """
+    Own Dungeon (default/false): Randomized within the dungeon they're normally found in
+    Anywhere (true): Items are in completely random locations
+    """
     display_name = "Dungeon Compasses Shuffle"
 
 class GoalVaati(DefaultOnToggle):
     """
     If enabled, DHC will open after completing Pedestal. Kill Vaati to goal.
-    If disabled, complete Pedestal to goal. DHC/Vaati is unecessary.
+    If disabled, complete Pedestal to goal. DHC/Vaati is unnecessary.
     """
     display_name = "Vaati Goal"
 

--- a/worlds/tmc/Rules.py
+++ b/worlds/tmc/Rules.py
@@ -1471,7 +1471,7 @@ class MinishCapRules():
             #region Dungeon TOD
             #TMCLocation.DROPLETS_ENTRANCE_B2_EAST_ICEBLOCK: none
             TMCLocation.DROPLETS_ENTRANCE_B2_WEST_ICEBLOCK:
-                self.has(TMCItem.SMALL_KEY_TOD,4),
+                self.has(TMCItem.SMALL_KEY_TOD,1), #FIXME: correct so that ToD placement with dungeon items works... better
             #endregion
 
             #region Dungeon TOD after Big Key

--- a/worlds/tmc/__init__.py
+++ b/worlds/tmc/__init__.py
@@ -11,11 +11,11 @@ import os
 import settings
 from BaseClasses import Tutorial, Item, Region, Location, LocationProgressType, ItemClassification
 from worlds.AutoWorld import WebWorld, World
-from .Options import MinishCapOptions, DungeonItem, get_option_data
+from .Options import MinishCapOptions, DungeonItem, ShuffleElements, get_option_data
 from .Items import ItemData, item_frequencies, item_table, itemList, item_groups, filler_item_selection, get_item_pool
 from .Locations import all_locations, DEFAULT_SET, OBSCURE_SET, POOL_RUPEE, location_groups, GOAL_VAATI, GOAL_PED
-from .constants import TMCEvent, MinishCapItem, MinishCapLocation
-from .dungeons import dungeon_fill
+from .constants import TMCEvent, TMCItem, MinishCapItem, MinishCapLocation
+from .dungeons import fill_dungeons
 from .Client import MinishCapClient
 from .Regions import create_regions
 from .Rom import MinishCapProcedurePatch, write_tokens
@@ -87,6 +87,12 @@ class MinishCapWorld(World):
         if self.options.obscure_spots.value:
             enabled_pools |= OBSCURE_SET
 
+        if self.options.shuffle_elements.value == ShuffleElements.option_own_dungeon:
+            self.options.start_hints.value.add(TMCItem.EARTH_ELEMENT)
+            self.options.start_hints.value.add(TMCItem.FIRE_ELEMENT)
+            self.options.start_hints.value.add(TMCItem.WATER_ELEMENT)
+            self.options.start_hints.value.add(TMCItem.WIND_ELEMENT)
+
         self.disabled_locations = set(loc.name for loc in all_locations if not loc.pools.issubset(enabled_pools))
 
     def fill_slot_data(self) -> Dict[str, any]:
@@ -150,7 +156,7 @@ class MinishCapWorld(World):
         # visualize_regions(self.multiworld.get_region("Menu", self.player), "tmc_world.puml")
 
     def pre_fill(self) -> None:
-        dungeon_fill(self, self.item_pool, self.pre_fill_pool)
+        fill_dungeons(self)
 
     def generate_output(self, output_directory: str) -> None:
         patch = MinishCapProcedurePatch(player = self.player, player_name = self.multiworld.player_name[self.player])

--- a/worlds/tmc/__init__.py
+++ b/worlds/tmc/__init__.py
@@ -15,6 +15,7 @@ from .Options import MinishCapOptions, DungeonItem, get_option_data
 from .Items import ItemData, item_frequencies, item_table, itemList, item_groups, filler_item_selection, get_item_pool
 from .Locations import all_locations, DEFAULT_SET, OBSCURE_SET, POOL_RUPEE, location_groups, GOAL_VAATI, GOAL_PED
 from .constants import TMCEvent, MinishCapItem, MinishCapLocation
+from .dungeons import dungeon_fill
 from .Client import MinishCapClient
 from .Regions import create_regions
 from .Rom import MinishCapProcedurePatch, write_tokens
@@ -71,6 +72,8 @@ class MinishCapWorld(World):
     item_name_to_id = {name: data.item_id for name, data in item_table.items()}
     location_name_to_id = {loc_data.name: loc_data.id for loc_data in all_locations}
     item_name_groups = item_groups
+    item_pool = []
+    pre_fill_pool = []
     location_name_groups = location_groups
     disabled_locations: Set[str]
 
@@ -122,7 +125,9 @@ class MinishCapWorld(World):
 
     def create_items(self):
         # First add in all progression and useful items
-        item_pool = get_item_pool(self)
+        item_pool, pre_fill_pool = get_item_pool(self)
+        self.item_pool = item_pool
+        self.pre_fill_pool = pre_fill_pool
         total_locations = len(self.multiworld.get_unfilled_locations(self.player))
         required_items = []
         precollected = [item for item in item_pool if item in self.multiworld.precollected_items]
@@ -136,13 +141,16 @@ class MinishCapWorld(World):
         for item in required_items:
             self.multiworld.itempool.append(item)
 
-        for _ in range(total_locations - len(required_items)):
+        for _ in range(total_locations - len(required_items) - len(pre_fill_pool)):
             self.multiworld.itempool.append(self.create_filler())
 
     def set_rules(self) -> None:
         MinishCapRules(self).set_rules(self.disabled_locations, self.location_name_to_id)
         # from Utils import visualize_regions
         # visualize_regions(self.multiworld.get_region("Menu", self.player), "tmc_world.puml")
+
+    def pre_fill(self) -> None:
+        dungeon_fill(self, self.item_pool, self.pre_fill_pool)
 
     def generate_output(self, output_directory: str) -> None:
         patch = MinishCapProcedurePatch(player = self.player, player_name = self.multiworld.player_name[self.player])

--- a/worlds/tmc/dungeons.py
+++ b/worlds/tmc/dungeons.py
@@ -1,0 +1,105 @@
+from Fill import fill_restrictive
+from typing import TYPE_CHECKING
+from BaseClasses import CollectionState
+
+from .constants import DUNGEON_ABBR, TMCItem, MinishCapItem, DUNGEON_REGIONS, TMCLocation
+from .Items import pool_elements
+from .Options import DungeonItem, ShuffleElements
+
+if TYPE_CHECKING:
+    from . import MinishCapWorld
+
+DUNGEON_ITEMS = {
+    "DWS": {
+        "dungeon_big_keys": [TMCItem.BIG_KEY_DWS],
+        "dungeon_small_keys": [TMCItem.SMALL_KEY_DWS] * 4,
+        "dungeon_compasses": [TMCItem.DUNGEON_COMPASS_DWS],
+        "dungeon_maps": [TMCItem.DUNGEON_MAP_DWS],
+    },
+    "CoF": {
+        "dungeon_big_keys": [TMCItem.BIG_KEY_COF],
+        "dungeon_small_keys": [TMCItem.SMALL_KEY_COF] * 2,
+        "dungeon_compasses": [TMCItem.DUNGEON_COMPASS_COF],
+        "dungeon_maps": [TMCItem.DUNGEON_MAP_COF],
+    },
+    "FoW": {
+        "dungeon_big_keys": [TMCItem.BIG_KEY_FOW],
+        "dungeon_small_keys": [TMCItem.SMALL_KEY_FOW] * 4,
+        "dungeon_compasses": [TMCItem.DUNGEON_COMPASS_FOW],
+        "dungeon_maps": [TMCItem.DUNGEON_MAP_FOW],
+    },
+    "ToD": {
+        "dungeon_big_keys": [TMCItem.BIG_KEY_TOD],
+        "dungeon_small_keys": [TMCItem.SMALL_KEY_TOD] * 4,
+        "dungeon_compasses": [TMCItem.DUNGEON_COMPASS_TOD],
+        "dungeon_maps": [TMCItem.DUNGEON_MAP_TOD],
+    },
+    "RC": {
+        "dungeon_big_keys": [],
+        "dungeon_small_keys": [TMCItem.SMALL_KEY_RC] * 3,
+        "dungeon_compasses": [],
+        "dungeon_maps": [],
+    },
+    "PoW": {
+        "dungeon_big_keys": [TMCItem.BIG_KEY_POW],
+        "dungeon_small_keys": [TMCItem.SMALL_KEY_POW] * 6,
+        "dungeon_compasses": [TMCItem.DUNGEON_COMPASS_POW],
+        "dungeon_maps": [TMCItem.DUNGEON_MAP_POW],
+    },
+    "DHC": {
+        "dungeon_big_keys": [TMCItem.BIG_KEY_DHC],
+        "dungeon_small_keys": [TMCItem.SMALL_KEY_DHC] * 5,
+        "dungeon_compasses": [TMCItem.DUNGEON_COMPASS_DHC],
+        "dungeon_maps": [TMCItem.DUNGEON_MAP_DHC],
+    },
+}
+"""
+
+"""
+
+BANNED_DUNGEON_LOCS = {
+    TMCLocation.DEEPWOOD_PRIZE, TMCLocation.DEEPWOOD_BOSS_ITEM,
+    TMCLocation.COF_PRIZE, TMCLocation.COF_BOSS_ITEM,
+    TMCLocation.FORTRESS_PRIZE, TMCLocation.FORTRESS_BOSS_ITEM,
+    TMCLocation.DROPLETS_PRIZE, TMCLocation.DROPLETS_BOSS_ITEM,
+    TMCLocation.CRYPT_PRIZE,
+    TMCLocation.PALACE_PRIZE, TMCLocation.PALACE_BOSS_ITEM,
+}
+"""
+A set of locations that dungeon filling should never place dungeon items at.
+Nobody wants to receive their Dungeon Map/Compass as the boss item.
+"""
+
+def dungeon_fill(world: "MinishCapWorld", base_pool: list[MinishCapItem], dungeon_pool: dict[str, list[MinishCapItem]]):
+    multiworld = world.multiworld
+    # settings are in this order because `fill_restrictive` `pop`s them for the placement order. Big Keys go first because ToD & PoW are a pain.
+    settings = ["dungeon_compasses", "dungeon_maps", "dungeon_small_keys", "dungeon_big_keys"]
+    items = {dungeon_key: [] for dungeon_key in DUNGEON_ABBR}
+
+    for setting in settings:
+        # If the setting is disabled, skip filling that item group
+        if getattr(world.options, setting) == DungeonItem.option_anywhere:
+            continue
+        # Else add it all the items in that setting pool to the fill stage
+        for dungeon in DUNGEON_ABBR:
+            items[dungeon].extend(map(world.create_item, DUNGEON_ITEMS[dungeon][setting]))
+
+    # Initialize collection state to assume player has all items except dungeon keys
+    all_state = CollectionState(multiworld)
+    collection = [all_state.collect(item) for item in multiworld.itempool if item.player == world.player]
+    if world.options.shuffle_elements is not ShuffleElements.option_anywhere:
+        for element in pool_elements():
+            all_state.collect(world.create_item(element.item_name))
+    for dungeon in DUNGEON_ABBR:
+        locations = []
+        for region in world.get_regions():
+            if region.name not in DUNGEON_REGIONS[dungeon]:
+                continue
+            for loc in region.get_locations():
+                if loc.item is not None or loc.name in BANNED_DUNGEON_LOCS:
+                    continue
+                locations.append(loc)
+        world.random.shuffle(locations)
+        # locations = [loc for region in world.get_regions() for loc in region.get_locations() if region in DUNGEON_REGIONS[dungeon]]
+        fill_restrictive(multiworld, all_state, locations, items[dungeon],
+            single_player_placement=True, lock=True, allow_excluded=True, name=f"TMC Dungeon Fill: {dungeon}")

--- a/worlds/tmc/dungeons.py
+++ b/worlds/tmc/dungeons.py
@@ -1,9 +1,8 @@
-from Fill import fill_restrictive
 from typing import TYPE_CHECKING
+from Fill import fill_restrictive
 from BaseClasses import CollectionState
 
 from .constants import DUNGEON_ABBR, TMCItem, MinishCapItem, DUNGEON_REGIONS, TMCLocation
-from .Items import pool_elements
 from .Options import DungeonItem, ShuffleElements
 
 if TYPE_CHECKING:
@@ -53,26 +52,33 @@ DUNGEON_ITEMS = {
         "dungeon_maps": [TMCItem.DUNGEON_MAP_DHC],
     },
 }
-"""
 
-"""
+ELEMENT_LOCATIONS = frozenset({
+    TMCLocation.DEEPWOOD_PRIZE,
+    TMCLocation.COF_PRIZE,
+    TMCLocation.DROPLETS_PRIZE,
+    TMCLocation.PALACE_PRIZE,
+    TMCLocation.FORTRESS_PRIZE,
+    TMCLocation.CRYPT_PRIZE
+})
 
-BANNED_DUNGEON_LOCS = {
+BANNED_KEY_LOCATIONS = frozenset({
     TMCLocation.DEEPWOOD_PRIZE, TMCLocation.DEEPWOOD_BOSS_ITEM,
     TMCLocation.COF_PRIZE, TMCLocation.COF_BOSS_ITEM,
     TMCLocation.FORTRESS_PRIZE, TMCLocation.FORTRESS_BOSS_ITEM,
     TMCLocation.DROPLETS_PRIZE, TMCLocation.DROPLETS_BOSS_ITEM,
     TMCLocation.CRYPT_PRIZE,
     TMCLocation.PALACE_PRIZE, TMCLocation.PALACE_BOSS_ITEM,
-}
+})
 """
 A set of locations that dungeon filling should never place dungeon items at.
 Nobody wants to receive their Dungeon Map/Compass as the boss item.
 """
 
-def dungeon_fill(world: "MinishCapWorld", base_pool: list[MinishCapItem], dungeon_pool: dict[str, list[MinishCapItem]]):
+def fill_dungeons(world: "MinishCapWorld"):
     multiworld = world.multiworld
-    # settings are in this order because `fill_restrictive` `pop`s them for the placement order. Big Keys go first because ToD & PoW are a pain.
+    # settings are in this order because `fill_restrictive` `pop`s them for the placement order.
+    # Big Keys go first because ToD & PoW are a pain.
     settings = ["dungeon_compasses", "dungeon_maps", "dungeon_small_keys", "dungeon_big_keys"]
     items = {dungeon_key: [] for dungeon_key in DUNGEON_ABBR}
 
@@ -87,19 +93,47 @@ def dungeon_fill(world: "MinishCapWorld", base_pool: list[MinishCapItem], dungeo
     # Initialize collection state to assume player has all items except dungeon keys
     all_state = CollectionState(multiworld)
     collection = [all_state.collect(item) for item in multiworld.itempool if item.player == world.player]
-    if world.options.shuffle_elements is not ShuffleElements.option_anywhere:
-        for element in pool_elements():
-            all_state.collect(world.create_item(element.item_name))
-    for dungeon in DUNGEON_ABBR:
-        locations = []
-        for region in world.get_regions():
-            if region.name not in DUNGEON_REGIONS[dungeon]:
-                continue
-            for loc in region.get_locations():
-                if loc.item is not None or loc.name in BANNED_DUNGEON_LOCS:
-                    continue
-                locations.append(loc)
+
+    # Dungeon Keys/Maps/Compasses
+    # Exclude DHC until Elements are placed
+    for dungeon in ["DWS", "CoF", "FoW", "ToD", "RC", "PoW"]:
+        fill_dungeon(world, dungeon, items[dungeon], all_state)
+
+    # Element Shuffle
+    # Place after the first 6 dungeons so that the prize locations are guaranteed reachable from the dungeon fill
+    elements = list(map(world.create_item,
+        [TMCItem.EARTH_ELEMENT, TMCItem.FIRE_ELEMENT, TMCItem.WATER_ELEMENT, TMCItem.WIND_ELEMENT])) # Order matters
+    if world.options.shuffle_elements.value is ShuffleElements.option_own_dungeon:
+        # Place elements into any "prize" location, shuffle locations
+        locations = [loc for loc in world.get_locations() if loc.name in ELEMENT_LOCATIONS]
         world.random.shuffle(locations)
-        # locations = [loc for region in world.get_regions() for loc in region.get_locations() if region in DUNGEON_REGIONS[dungeon]]
-        fill_restrictive(multiworld, all_state, locations, items[dungeon],
-            single_player_placement=True, lock=True, allow_excluded=True, name=f"TMC Dungeon Fill: {dungeon}")
+        # Don't allow excluded locations so that players can ban specific dungeons
+        fill_restrictive(multiworld, all_state, locations, elements,
+            single_player_placement=True, lock=True, allow_excluded=False, name="TMC Element Fill")
+    elif world.options.shuffle_elements.value is ShuffleElements.option_original_dungeon:
+        # Place elements into ordered locations, don't shuffle
+        locations = []
+        locations.append(world.get_location(TMCLocation.DEEPWOOD_PRIZE))
+        locations.append(world.get_location(TMCLocation.COF_PRIZE))
+        locations.append(world.get_location(TMCLocation.DROPLETS_PRIZE))
+        locations.append(world.get_location(TMCLocation.PALACE_PRIZE))
+        fill_restrictive(multiworld, all_state, locations, elements,
+            single_player_placement=True, lock=True, allow_excluded=True, name="TMC Element Fill")
+
+    # Fill DHC last since it needs the elements to be reachable
+    fill_dungeon(world, "DHC", items["DHC"], all_state)
+
+def fill_dungeon(world: "MinishCapWorld", dungeon: str, items: list[MinishCapItem], all_state: CollectionState):
+    multiworld = world.multiworld
+    locations = []
+    for region in world.get_regions():
+        if region.name not in DUNGEON_REGIONS[dungeon]:
+            continue
+        for loc in region.get_locations():
+            if loc.item is not None or loc.name in BANNED_KEY_LOCATIONS:
+                continue
+            locations.append(loc)
+    world.random.shuffle(locations)
+    # locations = [loc for region in world.get_regions() for loc in region.get_locations() if region in DUNGEON_REGIONS[dungeon]]
+    fill_restrictive(multiworld, all_state, locations, items,
+        single_player_placement=True, lock=True, allow_excluded=True, name=f"TMC Dungeon Fill: {dungeon}")

--- a/worlds/tmc/test/test_goal.py
+++ b/worlds/tmc/test/test_goal.py
@@ -4,14 +4,19 @@ from . import MinishCapTestBase
 class TestVaati(MinishCapTestBase):
     options = {
         "goal_vaati": True,
+        "shuffle_elements": True,
+        "dungeon_small_keys": True,
+        "dungeon_big_keys": True,
     }
 
-    def test_goal(self) -> None:
+    def test_goal_vaati(self) -> None:
         """Test some different states to verify goal requires the correct items"""
-        self.collect_all_but(["Big Key (DHC)", "Victory"])
+        self.collect_by_name(["Small Key (DHC)", "Big Key (DHC)"])
+        self.assertEqual(self.can_reach_location("DHC B1 Big Chest"), False)
+        self.collect_by_name(["Earth Element", "Fire Element", "Water Element", "Wind Element"])
         self.assertEqual(self.can_reach_location("DHC B1 Big Chest"), True)
         self.assertBeatable(False)
-        self.collect_by_name(["Big Key (DHC)"])
+        self.collect_by_name(["Progressive Sword", "Gust Jar", "Progressive Bow", "Cane of Pacci", "Lantern", "Bomb Bag", "Spin Attack"])
         self.assertBeatable(True)
 
 class TestPedestal(MinishCapTestBase):
@@ -20,7 +25,7 @@ class TestPedestal(MinishCapTestBase):
         "shuffle_elements": True,
     }
 
-    def test_goal(self) -> None:
+    def test_goal_pedestal(self) -> None:
         """Test whether Pedestal is only accessible once all elements are obtained"""
         self.collect_by_name(["Earth Element", "Fire Element", "Water Element"])
         self.assertBeatable(False)


### PR DESCRIPTION
- Added an dungeon keys, maps & compasses settings to force them into their own dungeons.
- Changed Element Shuffle to place during the pre_fill step rather than create_items. Also makes Element Shuffle respect `excluded_locations`