### PR TITLE
TMC: More v0.1.0 fixes

### DIFF
--- a/worlds/tmc/Items.py
+++ b/worlds/tmc/Items.py
@@ -239,8 +239,6 @@ def get_pre_fill_pool(world: "MinishCapWorld") -> list[MinishCapItem]:
         pre_fill_pool.extend(pool_compass(world))
     if not world.options.dungeon_maps.value == DungeonItem.option_anywhere:
         pre_fill_pool.extend(pool_dungeonmaps(world))
-    if not world.options.shuffle_elements.value is ShuffleElements.option_anywhere:
-        pre_fill_pool.extend(pool_elements())
 
     # Keep track of items that need to be removed due to start_inv
     known_start_inv = {}

--- a/worlds/tmc/Locations.py
+++ b/worlds/tmc/Locations.py
@@ -1,4 +1,3 @@
-import typing
 from dataclasses import dataclass
 
 from .constants import TMCLocation, TMCRegion, TMCEvent, TMCItem, DUNGEON_REGIONS
@@ -581,7 +580,7 @@ all_locations: list[LocationData] = [
     # region Lake Hylia
     LocationData(
         6029138, TMCLocation.HYLIA_SUNKEN_HP, TMCRegion.LAKE_HYLIA_NORTH,
-        TMCItem.HEART_PIECE, (0x0F323B, None), (0x2CBD, 0x02), 0x000B, pools={POOL_HP}
+        TMCItem.HEART_PIECE, (0x0F323B, None), (0x2CBD, 0x02), 0x000B, pools={POOL_HP, POOL_WATER}
     ),
     LocationData(
         6029139, TMCLocation.HYLIA_DOG_NPC, TMCRegion.LAKE_HYLIA_NORTH,

--- a/worlds/tmc/Rom.py
+++ b/worlds/tmc/Rom.py
@@ -95,9 +95,9 @@ def write_tokens(world: "MinishCapWorld", patch: MinishCapProcedurePatch) -> Non
                     loc.vanilla_item].classification != ItemClassification.filler):
             if loc.rom_addr[0] is None:
                 continue
-            item_inject(world, patch, location_table_by_name[location_name], world.create_filler())
+            item_inject(world, patch, location_table_by_name[location_name], world.create_item(TMCItem.RUPEES_1))
             continue
-        elif location_name in world.disabled_locations:
+        if location_name in world.disabled_locations:
             continue
         location = world.get_location(location_name)
         item = location.item

--- a/worlds/tmc/__init__.py
+++ b/worlds/tmc/__init__.py
@@ -10,11 +10,13 @@ import typing
 import settings
 from BaseClasses import Item, ItemClassification, Tutorial
 from worlds.AutoWorld import WebWorld, World
+from Fill import FillError
 from Options import OptionError
 from .Client import MinishCapClient
 from .constants import MinishCapItem, MinishCapLocation, TMCEvent, TMCItem, TMCLocation, TMCRegion
 from .dungeons import fill_dungeons
-from .Items import get_filler_item_selection, get_item_pool, get_pre_fill_pool, item_frequencies, item_groups, item_table, ItemData
+from .Items import (get_filler_item_selection, get_item_pool, get_pre_fill_pool, item_frequencies, item_groups,
+                    item_table, ItemData)
 from .Locations import (all_locations, DEFAULT_SET, GOAL_PED, GOAL_VAATI, location_groups, OBSCURE_SET, POOL_RUPEE,
                         POOL_POT, POOL_DIG, POOL_WATER)
 from .Options import DungeonItem, get_option_data, MinishCapOptions, ShuffleElements
@@ -165,16 +167,39 @@ class MinishCapWorld(World):
         return self.random.choice(self.filler_items)
 
     def create_items(self):
-        # First add in all progression and useful items
+        # Force vanilla elements into their pre-determined locations (must happen before pre_fill for plando)
+        if self.options.shuffle_elements.value is ShuffleElements.option_vanilla:
+            # Place elements into ordered locations, don't shuffle
+            location_names = [TMCLocation.DEEPWOOD_PRIZE, TMCLocation.COF_PRIZE, TMCLocation.DROPLETS_PRIZE,
+                              TMCLocation.PALACE_PRIZE]
+            item_names = [TMCItem.EARTH_ELEMENT, TMCItem.FIRE_ELEMENT, TMCItem.WATER_ELEMENT, TMCItem.WIND_ELEMENT]
+            for location_name, item_name in zip(location_names, item_names):
+                loc = self.get_location(location_name)
+                if loc.item is not None:
+                    raise FillError(f"Slot '{self.player_name}' used 'shuffle_elements: vanilla' but location "
+                                    f"'{location_name}' was already filled with '{loc.item.name}'")
+                loc.place_locked_item(self.create_item(item_name))
+        elif self.options.shuffle_elements.value is ShuffleElements.option_dungeon_prize:
+            # Get unfilled prize locations, shuffle, and place each element
+            location_names = [TMCLocation.DEEPWOOD_PRIZE, TMCLocation.COF_PRIZE, TMCLocation.FORTRESS_PRIZE,
+                              TMCLocation.DROPLETS_PRIZE, TMCLocation.PALACE_PRIZE, TMCLocation.CRYPT_PRIZE]
+            locations = list(self.multiworld.get_unfilled_locations_for_players(location_names, [self.player]))
+            if len(locations) < 4:
+                raise FillError(f"Slot '{self.player_name}' used 'shuffle_elements: dungeon_prize' but only "
+                                f"{len(locations)}/6 prize locations are available to fill the 4 elements")
+            locations = self.random.sample(locations, k=4)
+            item_names = [TMCItem.EARTH_ELEMENT, TMCItem.FIRE_ELEMENT, TMCItem.WATER_ELEMENT, TMCItem.WIND_ELEMENT]
+            for location, item_name in zip(locations, item_names):
+                location.place_locked_item(self.create_item(item_name))
+
+        # Add in all progression and useful items
         self.item_pool = get_item_pool(self)
         self.pre_fill_pool = get_pre_fill_pool(self)
         total_locations = len(self.multiworld.get_unfilled_locations(self.player))
 
-        for item in self.item_pool:
-            self.multiworld.itempool.append(item)
-
-        for _ in range(total_locations - len(self.item_pool) - len(self.pre_fill_pool)):
-            self.multiworld.itempool.append(self.create_filler())
+        self.multiworld.itempool.extend(self.item_pool)
+        filler = [self.create_filler() for _ in range(total_locations - len(self.item_pool) - len(self.pre_fill_pool))]
+        self.multiworld.itempool.extend(filler)
 
     def set_rules(self) -> None:
         MinishCapRules(self).set_rules(self.disabled_locations, self.location_name_to_id)

--- a/worlds/tmc/dungeons.py
+++ b/worlds/tmc/dungeons.py
@@ -1,10 +1,9 @@
 from typing import TYPE_CHECKING
 
 from BaseClasses import CollectionState
-from Fill import fill_restrictive
-from .constants import DUNGEON_ABBR, TMCItem, TMCLocation
+from Fill import fill_restrictive, FillError
+from .constants import TMCItem, TMCLocation
 from .Locations import location_groups
-from .Options import ShuffleElements
 
 if TYPE_CHECKING:
     from . import MinishCapWorld
@@ -52,30 +51,6 @@ def fill_dungeons(world: "MinishCapWorld"):
     for item in world.item_pool:
         base_state.collect(item)
 
-    # Element Shuffle
-    elements = list(map(world.create_item, [TMCItem.EARTH_ELEMENT, TMCItem.FIRE_ELEMENT, TMCItem.WATER_ELEMENT,
-                                            TMCItem.WIND_ELEMENT]))
-    # Create an element state that will have all the items from future pre_fill stages
-    element_state = base_state.copy()
-    for pre_fill_item in world.get_pre_fill_items():
-        if pre_fill_item.name not in ELEMENTS:
-            element_state.collect(pre_fill_item, prevent_sweep=True)
-    element_state.sweep_for_advancements(multiworld.get_locations(world.player))
-
-    if world.options.shuffle_elements.value is ShuffleElements.option_dungeon_prize:
-        # Place elements into any "prize" location, shuffle locations
-        locations = [world.get_location(element_loc) for element_loc in ELEMENT_LOCATIONS]
-        world.random.shuffle(locations)
-        # Don't allow excluded locations so that players can ban specific dungeons
-        fill_restrictive(multiworld, element_state, locations, elements, single_player_placement=True, lock=True,
-                         allow_excluded=False, name="TMC Element Fill")
-    elif world.options.shuffle_elements.value is ShuffleElements.option_vanilla:
-        # Place elements into ordered locations, don't shuffle
-        locations = [world.get_location(TMCLocation.PALACE_PRIZE), world.get_location(TMCLocation.DROPLETS_PRIZE),
-                     world.get_location(TMCLocation.COF_PRIZE), world.get_location(TMCLocation.DEEPWOOD_PRIZE)]
-        fill_restrictive(multiworld, element_state, locations, elements, single_player_placement=True, lock=True,
-                         allow_excluded=True, name="TMC Element Fill")
-
     # Big Key, Small Key, Maps & Compass Fill
     for stage in [KEYS, MAPS_COMPASSES]:
         # Randomize dungeon order but keep DHC last to ensure access conditions are met
@@ -100,6 +75,11 @@ def fill_dungeon(world: "MinishCapWorld", dungeon: str, stage_items: set[str], b
     # Get list of locations that we can place items, filtered for current dungeon group
     fill_locations = [loc for loc in world_locations \
                       if loc.name in location_groups[dungeon] and loc.name not in BANNED_KEY_LOCATIONS]
+
+    if len(fill_locations) < len(fill_stage_items):
+        raise FillError(f"Not enough locations to pre_fill for slot '{world.player_name}', did plando or other "
+                        f"worlds fill too many of our dungeon locations?")
+
     world.random.shuffle(fill_locations)
     world.random.shuffle(fill_stage_items)
 


### PR DESCRIPTION
- Fix plando causing element fill to fail. Element fill now occurs before plando
- Fix Hylia Sunken HP not considered "underwater"
- Change disabled locations with vanilla progression items to fill with 1 Rupee rather than random filler